### PR TITLE
updated to version 1.3.0 for cflint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .dropbox
 lib
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 1.0.0
+
+* Upgraded CFLint to latest 1.3.0 release
+* Added the ability to suppress the display output if needed via the `suppress` argument
+* Added the ability to generate multiple output types at once
+* Added the ability to have the choice to fail with an exit code or note using the `exitOnError` argument, great for not failing CI builds if needed
+* New text report output by using the `text` argument
+* New json report output by using the `json` argument
+* Added types for CLI introspection and tab completion.
+
+## 0.5.0
+
+* Original Release

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a [CommandBox](https://www.ortussolutions.com/products/commandbox) module for linting your CFML code using [CFLint](https://github.com/cflint/CFLint).
 
-CFLint Version: 1.2.3
+CFLint Version: 1.3.0
 
 ## Install
 

--- a/box.json
+++ b/box.json
@@ -15,11 +15,11 @@
     "description":"CommandBox command for running CFLint",
     "type":"commandbox-modules",
     "dependencies":{
-        "CFLint-1.2.3-all":"jar:https://github.com/cflint/CFLint/releases/download/CFLint-1.2.3/CFLint-1.2.3-all.jar"
+        "CFLint-1.3.0-all":"jar:https://github.com/cflint/CFLint/releases/download/CFLint-1.3.0/CFLint-1.3.0-all.jar"
     },
     "devDependencies":{},
     "installPaths":{
-        "CFLint-1.2.3-all":"lib/CFLint-1.2.3-all"
+        "CFLint-1.3.0-all":"lib/CFLint-1.3.0-all"
     },
     "scripts":{
         "postVersion":"package set location='jsteinshouer/commandbox-cflint#v`package version`'",
@@ -28,8 +28,10 @@
     },
     "ignore":[
         "**/.*",
-        "test",
         "tests",
         "examples"
+    ],
+    "contributors":[
+        "Luis Majano <lmajano@ortussolutions.com>"
     ]
 }

--- a/commands/cflint.cfc
+++ b/commands/cflint.cfc
@@ -21,9 +21,9 @@ component {
 	* Constructor
 	*/
 	function init() {
-		variables.workDirectory = fileSystemUtil.resolvePath( "." );
-		variables.rootPath = REReplaceNoCase( getDirectoryFromPath( getCurrentTemplatePath() ), "commands(\\|/)", "" );
-		variables.cflintJAR = rootPath & "lib/cflint-1.2.3-all/cflint-1.2.3-all.jar";
+		variables.workDirectory  = fileSystemUtil.resolvePath( "." );
+		variables.rootPath       = REReplaceNoCase( getDirectoryFromPath( getCurrentTemplatePath() ), "commands(\\|/)", "" );
+		variables.cflintJAR      = rootPath & "lib/cflint-1.3.0-all/cflint-1.3.0-all.jar";
 		variables.reportTemplate = "/commandbox-cflint/resources/report.cfm" ;
 		variables.htmlResultFile = workDirectory & "cflint-results.html";
 


### PR DESCRIPTION
* Upgraded CFLint to latest 1.3.0 release
* Added the ability to suppress the display output if needed via the `suppress` argument
* Added the ability to generate multiple output types at once
* Added the ability to have the choice to fail with an exit code or note using the `exitOnError` argument, great for not failing CI builds if needed
* New text report output by using the `text` argument
* New json report output by using the `json` argument
* Added types for CLI introspection and tab completion.