### PR TITLE
Case Sensitive OS issues + Ability to do multiple pattern lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.0
+
+* Fix for case sensitive OSs
+* Added the ability for the `pattern` argument to accept a list of globbing patterns: ex `models/**.cfc,modules_app/**.cfc`
+
 ## 1.0.0
 
 * Upgraded CFLint to latest 1.3.0 release

--- a/box.json
+++ b/box.json
@@ -1,8 +1,8 @@
 {
     "name":"commandbox-cflint",
-    "version":"1.0.0",
+    "version":"1.0.1",
     "author":"Jason Steinshouer",
-    "location":"jsteinshouer/commandbox-cflint#v1.0.0",
+    "location":"jsteinshouer/commandbox-cflint#v1.0.1",
     "homepage":"https://github.com/jsteinshouer/commandbox-cflint",
     "documentation":"https://github.com/jsteinshouer/commandbox-cflint",
     "repository":{

--- a/box.json
+++ b/box.json
@@ -1,8 +1,8 @@
 {
     "name":"commandbox-cflint",
-    "version":"1.0.1",
+    "version":"1.1.0",
     "author":"Jason Steinshouer",
-    "location":"jsteinshouer/commandbox-cflint#v1.0.1",
+    "location":"jsteinshouer/commandbox-cflint#v1.1.0",
     "homepage":"https://github.com/jsteinshouer/commandbox-cflint",
     "documentation":"https://github.com/jsteinshouer/commandbox-cflint",
     "repository":{

--- a/commands/cflint.cfc
+++ b/commands/cflint.cfc
@@ -26,7 +26,7 @@ component{
 	function init(){
 		variables.workDirectory  = fileSystemUtil.resolvePath( "." );
 		variables.rootPath       = REReplaceNoCase( getDirectoryFromPath( getCurrentTemplatePath() ), "commands(\\|/)", "" );
-		variables.cflintJAR      = rootPath & "lib/cflint-#variables.CFLINT_VERSION#-all/cflint-#variables.CFLINT_VERSION#-all.jar";
+		variables.cflintJAR      = rootPath & "lib/CFLint-#variables.CFLINT_VERSION#-all/CFLint-#variables.CFLINT_VERSION#-all.jar";
 		variables.reportTemplate = "/commandbox-cflint/resources/report.cfm" ;
 
 		return this;


### PR DESCRIPTION
## 1.1.0

* Fix for case sensitive OSs
* Added the ability for the `pattern` argument to accept a list of globbing patterns: ex `models/**.cfc,modules_app/**.cfc`
