### PR TITLE
Fix the pattern argument for the run function

### DIFF
--- a/commands/cflint.cfc
+++ b/commands/cflint.cfc
@@ -55,7 +55,7 @@ component{
 		var fullFilePaths = [];
 		// Split pattern for lists of globbing patterns
 		arguments.pattern
-			.listToArray()
+			.listToArray( "|" )
 			.each( function( item ){
 				fullFilePaths.append(
 					globber( workDirectory & item ).matches(), true


### PR DESCRIPTION
The pattern is using a non standard pipe delimiter rather than a comma, so the `listoToArray()` function needs that as well.