### PR TITLE
Adding ability to filter out levels of errors. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ box install commandbox-cflint
 
 ## Usage
 
-It can be run on a single file or aginst a list of files defined by a file globbing pattern
+It can be run on a single file or against a list of files defined by a file globing pattern
 
 ```
 box cflint **.cfc,**.cfm
@@ -30,6 +30,18 @@ Generate html report instead of console output.
 
 ```
 box cflint models/**.cfc --html
+```
+
+Hide INFO level results.
+
+```
+box cflint reportLevel=WARNING
+```
+
+Hide INFO and WARNING level results.
+
+```
+box cflint reportLevel=ERROR
 ```
 
 ## Example Output


### PR DESCRIPTION
I added the ability to filter out INFO and WARNING level cflint findings. Since this is not supported in flint  I had to manually do it. 

To test install this version of the module. 

Run ```box flint reportLevel=ERROR``` 

Should get 1 error message but not any warnings or INFO level messages. 