### PR TITLE
Strip .xml file extension from fileName param - fixes #8

### DIFF
--- a/commands/cflint.cfc
+++ b/commands/cflint.cfc
@@ -122,7 +122,7 @@ component{
 		// Run the linter
 		var reportData = getReportData( arguments.files , arguments.reportLevel );
 		var workDirectory  = fileSystemUtil.resolvePath( "." );
-		var outputFile = workDirectory & "/" & arguments.fileName;
+		var outputFile = workDirectory & "/" & replace(arguments.fileName, ".xml", "" );
 
 		// Run Display Procedures
 		displayReport( reportData );


### PR DESCRIPTION
Simple replace any instance of `.xml` in the `fileName` parameter to avoid `myfile.xml.xml` output filename. :)

Fixes #8 

PS. I haven't tested this! Sorry!